### PR TITLE
Add ARM64 (aarch64) build support for Darling on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,8 @@ add_compile_definitions(
 	OS_CRASH_ENABLE_EXPERIMENTAL_LIBTRACE=1
 
 	# not in Xcode build files, but seems necessary to us
-	_DARWIN_NO_64_BIT_INODE=1
+	# _DARWIN_NO_64_BIT_INODE=1 is incompatible with ARM64 (only 64-bit inodes)
+	$<$<NOT:$<BOOL:${TARGET_ARM64}>>:_DARWIN_NO_64_BIT_INODE=1>
 	PRIVATE
 )
 

--- a/kext.subproj/cross_link.c
+++ b/kext.subproj/cross_link.c
@@ -22,6 +22,12 @@
  */
 #include "cross_link.h"
 
+/* On ARM64, PAGE_SHIFT_CONST is declared as extern int in kernel headers.
+ * This file is compiled with -DKERNEL, so we need to provide the definition.
+ * Darling uses 4KB pages (PAGE_SHIFT = 12). */
+#if defined(__aarch64__) || defined(__arm64__)
+int PAGE_SHIFT_CONST = 12;
+#endif
 
 /*********************************************************************
 * Module Internal Variables


### PR DESCRIPTION
Per-package ARM64 (aarch64) build adjustments so this submodule compiles cleanly under a Linux aarch64 host. Part of the ARM64 support series; the umbrella PR in `darlinghq/darling` references the rest.